### PR TITLE
Do not log retried exceptions as errors

### DIFF
--- a/JasperReports/JasperServer.py
+++ b/JasperReports/JasperServer.py
@@ -88,7 +88,6 @@ class JasperServer(UserWarning):
                 try:
                     return self.proxy.Report.execute(*args)
                 except (xmlrpc.client.ProtocolError, socket.error) as e:
-                    self.error("EXCEPTION: %s %s" % (str(e), str(e.args)))
                     pass
                 except xmlrpc.client.Fault as e:
                     self.error("EXCEPTION: %s %s" % (str(e), str(e.args)))


### PR DESCRIPTION
As the code is re-executed it does not make sense to log them as error until they all the retry loop is ended. 

When using a logconfig to notify errors (by email or using sentry) this error is logged when it should not be logged.